### PR TITLE
Setup Tag-Based Validation with Sanity Webhooks

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const config = {
   images: { remotePatterns: [{ hostname: 'cdn.sanity.io' }] },
+  logging: { fetches: { fullUrl: true } },
 }
 
 export default config

--- a/src/app/api/mail/route.ts
+++ b/src/app/api/mail/route.ts
@@ -48,7 +48,7 @@ ${field.label}:
     return NextResponse.json({ status: 200 })
   } catch (error) {
     console.log('Error sending email', error)
-    
+
     return new NextResponse(`There was an error sending the email`, {
       status: 500,
       statusText: JSON.stringify(error),

--- a/src/app/api/revalidate-tag/route.ts
+++ b/src/app/api/revalidate-tag/route.ts
@@ -1,0 +1,52 @@
+import { revalidateTag } from 'next/cache'
+import { type NextRequest, NextResponse } from 'next/server'
+import { parseBody } from 'next-sanity/webhook'
+
+type WebhookPayload = {
+  _type: string
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    if (!process.env.SANITY_REVALIDATE_SECRET) {
+      return new NextResponse(
+        'Missing environment variable SANITY_REVALIDATE_SECRET',
+        { status: 500 },
+      )
+    }
+
+    const { isValidSignature, body } = await parseBody<WebhookPayload>(
+      req,
+      process.env.SANITY_REVALIDATE_SECRET,
+    )
+
+    if (!isValidSignature) {
+      const message = 'Invalid signature'
+      return new NextResponse(
+        JSON.stringify({ message, isValidSignature, body }),
+        {
+          status: 401,
+        },
+      )
+    } else if (!body?._type) {
+      const message = 'Bad Request'
+      return new NextResponse(JSON.stringify({ message, body }), {
+        status: 400,
+      })
+    }
+
+    revalidateTag(body._type)
+
+    return NextResponse.json({ body })
+  } catch (error) {
+    console.error('Error in revalidate tag webhook endpoint.', error)
+
+    return new NextResponse(
+      `There was an error in revalidate tag webhook endpoint`,
+      {
+        status: 500,
+        statusText: JSON.stringify(error),
+      },
+    )
+  }
+}

--- a/src/app/api/revalidate-tag/route.ts
+++ b/src/app/api/revalidate-tag/route.ts
@@ -35,6 +35,7 @@ export async function POST(req: NextRequest) {
       })
     }
 
+    console.log('Revalidating tag for type', body._type)
     revalidateTag(body._type)
 
     return NextResponse.json({ body })

--- a/src/app/api/sanity/artist/route.ts
+++ b/src/app/api/sanity/artist/route.ts
@@ -9,7 +9,7 @@ import {
   logAuthorizedRequest,
   notAuthorizedResponse,
 } from '~/lib/next-auth/auth.utils'
-import { getClient } from '~/lib/sanity/sanity.client'
+import { getClient, NEXT_TAGS_CONFIG } from '~/lib/sanity/sanity.client'
 import { ImageReference } from '~/utils/images/uploadImagesToSanity'
 
 const token = process.env.SANITY_API_WRITE_TOKEN
@@ -24,7 +24,7 @@ const filterDuplicatePortfolioImages = async (
   const currentPortfolioImages: ImageReference[] = await client.fetch(
     groq`*[_id == $artistId][0].portfolioImages`,
     { artistId: artistId },
-    { next: { tags: ['artist'] } },
+    NEXT_TAGS_CONFIG.ARTIST,
   )
   const currentPortfolioImageRefs = currentPortfolioImages.map(
     (image) => image.asset._ref,

--- a/src/app/api/sanity/artist/route.ts
+++ b/src/app/api/sanity/artist/route.ts
@@ -9,7 +9,7 @@ import {
   logAuthorizedRequest,
   notAuthorizedResponse,
 } from '~/lib/next-auth/auth.utils'
-import { getClient, NEXT_TAGS_CONFIG } from '~/lib/sanity/sanity.client'
+import { getClient, NEXT_CACHE_CONFIG } from '~/lib/sanity/sanity.client'
 import { ImageReference } from '~/utils/images/uploadImagesToSanity'
 
 const token = process.env.SANITY_API_WRITE_TOKEN
@@ -24,7 +24,7 @@ const filterDuplicatePortfolioImages = async (
   const currentPortfolioImages: ImageReference[] = await client.fetch(
     groq`*[_id == $artistId][0].portfolioImages`,
     { artistId: artistId },
-    NEXT_TAGS_CONFIG.ARTIST,
+    NEXT_CACHE_CONFIG.ARTIST,
   )
   const currentPortfolioImageRefs = currentPortfolioImages.map(
     (image) => image.asset._ref,

--- a/src/app/api/sanity/artist/route.ts
+++ b/src/app/api/sanity/artist/route.ts
@@ -9,10 +9,7 @@ import {
   logAuthorizedRequest,
   notAuthorizedResponse,
 } from '~/lib/next-auth/auth.utils'
-import {
-  getClient,
-  SANITY_CLIENT_CACHE_SETTING,
-} from '~/lib/sanity/sanity.client'
+import { getClient } from '~/lib/sanity/sanity.client'
 import { ImageReference } from '~/utils/images/uploadImagesToSanity'
 
 const token = process.env.SANITY_API_WRITE_TOKEN
@@ -27,7 +24,7 @@ const filterDuplicatePortfolioImages = async (
   const currentPortfolioImages: ImageReference[] = await client.fetch(
     groq`*[_id == $artistId][0].portfolioImages`,
     { artistId: artistId },
-    SANITY_CLIENT_CACHE_SETTING,
+    { next: { tags: ['artist'] } },
   )
   const currentPortfolioImageRefs = currentPortfolioImages.map(
     (image) => image.asset._ref,

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -36,7 +36,9 @@ const Footer = (props: IFooter) => {
   })
 
   const extraNavGroup = ExtraNavLinks.map((navItem) => {
-    return <NavMenuLink key={navItem.label} navItem={navItem} />
+    return (
+      <NavMenuLink key={navItem.label} navItem={navItem} prefetch={false} />
+    )
   })
 
   return (

--- a/src/components/NavMenu/NavMenuLink.tsx
+++ b/src/components/NavMenu/NavMenuLink.tsx
@@ -9,6 +9,7 @@ import classes from './NavMenu.module.css'
 interface INavMenuLink {
   navItem: NavigationLink
   isHeader?: boolean
+  prefetch?: boolean | undefined
   onLinkClick?: (
     event: React.MouseEvent<HTMLAnchorElement>,
     link: string,
@@ -18,6 +19,7 @@ interface INavMenuLink {
 const NavMenuLink = ({
   navItem,
   isHeader = false,
+  prefetch = undefined,
   onLinkClick,
 }: INavMenuLink) => {
   const linkClass = isHeader ? classes.linkHeader : classes.linkFooter
@@ -27,6 +29,7 @@ const NavMenuLink = ({
       key={navItem.label}
       href={navItem.link}
       className={linkClass}
+      prefetch={prefetch}
       onClick={(event) => onLinkClick && onLinkClick(event, navItem.link)}
     >
       {navItem.label}

--- a/src/lib/sanity/queries/sanity.artistsQuery.ts
+++ b/src/lib/sanity/queries/sanity.artistsQuery.ts
@@ -5,20 +5,18 @@ import { SanityClient } from 'sanity'
 
 import { Artist } from '~/schemas/models/artist'
 
+import { NEXT_TAGS_CONFIG } from '../sanity.client'
+
 const artistsQuery = groq`*[_type == "artist"]`
 export async function getArtists(client: SanityClient): Promise<Artist[]> {
-  return await client.fetch(artistsQuery, {}, { next: { tags: ['artist'] } })
+  return await client.fetch(artistsQuery, {}, NEXT_TAGS_CONFIG.ARTIST)
 }
 
 const activeArtistsQuery = groq`*[_type == "artist" && isActive]`
 export async function getActiveArtists(
   client: SanityClient,
 ): Promise<Artist[]> {
-  return await client.fetch(
-    activeArtistsQuery,
-    {},
-    { next: { tags: ['artist'] } },
-  )
+  return await client.fetch(activeArtistsQuery, {}, NEXT_TAGS_CONFIG.ARTIST)
 }
 
 const artistsEmailQuery = groq`*[_type == "artist" && email == $email][0]{name, _id}`
@@ -27,9 +25,11 @@ export async function getArtistByEmail(
   email: string,
 ): Promise<Partial<Artist>> {
   const emailParam = { email: email.toLowerCase() }
-  return await client.fetch(artistsEmailQuery, emailParam, {
-    next: { tags: ['artist'] },
-  })
+  return await client.fetch(
+    artistsEmailQuery,
+    emailParam,
+    NEXT_TAGS_CONFIG.ARTIST,
+  )
 }
 
 const artistsIdQuery = groq`*[_type == "artist" && _id == $id][0]`
@@ -38,9 +38,7 @@ export async function getArtistById(
   id: string,
 ): Promise<Artist> {
   const idParam = { id: id }
-  return await client.fetch(artistsIdQuery, idParam, {
-    next: { tags: ['artist'] },
-  })
+  return await client.fetch(artistsIdQuery, idParam, NEXT_TAGS_CONFIG.ARTIST)
 }
 
 export interface BooksStatus {

--- a/src/lib/sanity/queries/sanity.artistsQuery.ts
+++ b/src/lib/sanity/queries/sanity.artistsQuery.ts
@@ -5,18 +5,20 @@ import { SanityClient } from 'sanity'
 
 import { Artist } from '~/schemas/models/artist'
 
-import { SANITY_CLIENT_CACHE_SETTING } from '../sanity.client'
-
 const artistsQuery = groq`*[_type == "artist"]`
 export async function getArtists(client: SanityClient): Promise<Artist[]> {
-  return await client.fetch(artistsQuery, {}, SANITY_CLIENT_CACHE_SETTING)
+  return await client.fetch(artistsQuery, {}, { next: { tags: ['artist'] } })
 }
 
 const activeArtistsQuery = groq`*[_type == "artist" && isActive]`
 export async function getActiveArtists(
   client: SanityClient,
 ): Promise<Artist[]> {
-  return await client.fetch(activeArtistsQuery, {}, SANITY_CLIENT_CACHE_SETTING)
+  return await client.fetch(
+    activeArtistsQuery,
+    {},
+    { next: { tags: ['artist'] } },
+  )
 }
 
 const artistsEmailQuery = groq`*[_type == "artist" && email == $email][0]{name, _id}`
@@ -25,11 +27,9 @@ export async function getArtistByEmail(
   email: string,
 ): Promise<Partial<Artist>> {
   const emailParam = { email: email.toLowerCase() }
-  return await client.fetch(
-    artistsEmailQuery,
-    emailParam,
-    SANITY_CLIENT_CACHE_SETTING,
-  )
+  return await client.fetch(artistsEmailQuery, emailParam, {
+    next: { tags: ['artist'] },
+  })
 }
 
 const artistsIdQuery = groq`*[_type == "artist" && _id == $id][0]`
@@ -38,11 +38,9 @@ export async function getArtistById(
   id: string,
 ): Promise<Artist> {
   const idParam = { id: id }
-  return await client.fetch(
-    artistsIdQuery,
-    idParam,
-    SANITY_CLIENT_CACHE_SETTING,
-  )
+  return await client.fetch(artistsIdQuery, idParam, {
+    next: { tags: ['artist'] },
+  })
 }
 
 export interface BooksStatus {

--- a/src/lib/sanity/queries/sanity.artistsQuery.ts
+++ b/src/lib/sanity/queries/sanity.artistsQuery.ts
@@ -5,18 +5,18 @@ import { SanityClient } from 'sanity'
 
 import { Artist } from '~/schemas/models/artist'
 
-import { NEXT_TAGS_CONFIG } from '../sanity.client'
+import { NEXT_CACHE_CONFIG } from '../sanity.client'
 
 const artistsQuery = groq`*[_type == "artist"]`
 export async function getArtists(client: SanityClient): Promise<Artist[]> {
-  return await client.fetch(artistsQuery, {}, NEXT_TAGS_CONFIG.ARTIST)
+  return await client.fetch(artistsQuery, {}, NEXT_CACHE_CONFIG.ARTIST)
 }
 
 const activeArtistsQuery = groq`*[_type == "artist" && isActive]`
 export async function getActiveArtists(
   client: SanityClient,
 ): Promise<Artist[]> {
-  return await client.fetch(activeArtistsQuery, {}, NEXT_TAGS_CONFIG.ARTIST)
+  return await client.fetch(activeArtistsQuery, {}, NEXT_CACHE_CONFIG.ARTIST)
 }
 
 const artistsEmailQuery = groq`*[_type == "artist" && email == $email][0]{name, _id}`
@@ -28,7 +28,7 @@ export async function getArtistByEmail(
   return await client.fetch(
     artistsEmailQuery,
     emailParam,
-    NEXT_TAGS_CONFIG.ARTIST,
+    NEXT_CACHE_CONFIG.ARTIST,
   )
 }
 
@@ -38,7 +38,7 @@ export async function getArtistById(
   id: string,
 ): Promise<Artist> {
   const idParam = { id: id }
-  return await client.fetch(artistsIdQuery, idParam, NEXT_TAGS_CONFIG.ARTIST)
+  return await client.fetch(artistsIdQuery, idParam, NEXT_CACHE_CONFIG.ARTIST)
 }
 
 export interface BooksStatus {

--- a/src/lib/sanity/queries/sanity.bookingsQuery.ts
+++ b/src/lib/sanity/queries/sanity.bookingsQuery.ts
@@ -4,11 +4,6 @@ import { SanityClient } from 'sanity'
 
 import { Booking } from '~/schemas/models/booking'
 
-export const bookingsQuery = groq`*[_type == "booking"] | order(_createdAt asc)`
-export async function getBookings(client: SanityClient): Promise<Booking[]> {
-  return await client.fetch(bookingsQuery, {}, { cache: 'no-store' })
-}
-
 export const bookingsByArtistIdQuery = groq`*[_type == "booking" && artist._ref == $artistId] | order(_createdAt asc)`
 export async function getBookingsByArtistId(
   client: SanityClient,
@@ -16,7 +11,7 @@ export async function getBookingsByArtistId(
 ): Promise<Booking[]> {
   const idParam = { artistId: id }
   return await client.fetch(bookingsByArtistIdQuery, idParam, {
-    cache: 'no-store',
+    next: { tags: ['booking'] },
   })
 }
 

--- a/src/lib/sanity/queries/sanity.bookingsQuery.ts
+++ b/src/lib/sanity/queries/sanity.bookingsQuery.ts
@@ -4,15 +4,19 @@ import { SanityClient } from 'sanity'
 
 import { Booking } from '~/schemas/models/booking'
 
+import { NEXT_TAGS_CONFIG } from '../sanity.client'
+
 export const bookingsByArtistIdQuery = groq`*[_type == "booking" && artist._ref == $artistId] | order(_createdAt asc)`
 export async function getBookingsByArtistId(
   client: SanityClient,
   id: string,
 ): Promise<Booking[]> {
   const idParam = { artistId: id }
-  return await client.fetch(bookingsByArtistIdQuery, idParam, {
-    next: { tags: ['booking'] },
-  })
+  return await client.fetch(
+    bookingsByArtistIdQuery,
+    idParam,
+    NEXT_TAGS_CONFIG.BOOKING,
+  )
 }
 
 export function listenForBookingChanges(

--- a/src/lib/sanity/queries/sanity.bookingsQuery.ts
+++ b/src/lib/sanity/queries/sanity.bookingsQuery.ts
@@ -4,7 +4,7 @@ import { SanityClient } from 'sanity'
 
 import { Booking } from '~/schemas/models/booking'
 
-import { NEXT_TAGS_CONFIG } from '../sanity.client'
+import { NEXT_CACHE_CONFIG } from '../sanity.client'
 
 export const bookingsByArtistIdQuery = groq`*[_type == "booking" && artist._ref == $artistId] | order(_createdAt asc)`
 export async function getBookingsByArtistId(
@@ -15,7 +15,7 @@ export async function getBookingsByArtistId(
   return await client.fetch(
     bookingsByArtistIdQuery,
     idParam,
-    NEXT_TAGS_CONFIG.BOOKING,
+    NEXT_CACHE_CONFIG.BOOKING,
   )
 }
 

--- a/src/lib/sanity/queries/sanity.pageContentQueries.ts
+++ b/src/lib/sanity/queries/sanity.pageContentQueries.ts
@@ -48,7 +48,7 @@ export async function getRootLayoutContent(
   return await client.fetch(
     rootLayoutContentQuery,
     {},
-    SANITY_CLIENT_CACHE_SETTING,
+    { next: { tags: ['rootLayoutContent'] } },
   )
 }
 
@@ -59,6 +59,6 @@ export async function getLayoutMetadata(
   return await client.fetch(
     layoutMetadataQuery,
     {},
-    SANITY_CLIENT_CACHE_SETTING,
+    { next: { tags: ['layoutMetadataContent'] } },
   )
 }

--- a/src/lib/sanity/queries/sanity.pageContentQueries.ts
+++ b/src/lib/sanity/queries/sanity.pageContentQueries.ts
@@ -12,7 +12,7 @@ import { PrivacyPolicyPageContent } from '~/schemas/pages/privacyPolicyPageConte
 import { RootLayoutContent } from '~/schemas/pages/rootLayoutContent'
 import { RootPageContent } from '~/schemas/pages/rootPageContent'
 
-import { getClient } from '../sanity.client'
+import { getClient, NEXT_TAGS_CONFIG } from '../sanity.client'
 
 type QueryReturnType = {
   rootPageContent: RootPageContent
@@ -48,7 +48,7 @@ export async function getRootLayoutContent(
   return await client.fetch(
     rootLayoutContentQuery,
     {},
-    { next: { tags: ['rootLayoutContent'] } },
+    NEXT_TAGS_CONFIG.ROOT_LAYOUT_CONTENT,
   )
 }
 
@@ -59,6 +59,6 @@ export async function getLayoutMetadata(
   return await client.fetch(
     layoutMetadataQuery,
     {},
-    { next: { tags: ['layoutMetadataContent'] } },
+    NEXT_TAGS_CONFIG.LAYOUT_METADATA_CONTENT,
   )
 }

--- a/src/lib/sanity/queries/sanity.pageContentQueries.ts
+++ b/src/lib/sanity/queries/sanity.pageContentQueries.ts
@@ -12,7 +12,7 @@ import { PrivacyPolicyPageContent } from '~/schemas/pages/privacyPolicyPageConte
 import { RootLayoutContent } from '~/schemas/pages/rootLayoutContent'
 import { RootPageContent } from '~/schemas/pages/rootPageContent'
 
-import { getClient, NEXT_TAGS_CONFIG } from '../sanity.client'
+import { getClient, NEXT_CACHE_CONFIG } from '../sanity.client'
 
 type QueryReturnType = {
   rootPageContent: RootPageContent
@@ -48,7 +48,7 @@ export async function getRootLayoutContent(
   return await client.fetch(
     rootLayoutContentQuery,
     {},
-    NEXT_TAGS_CONFIG.ROOT_LAYOUT_CONTENT,
+    NEXT_CACHE_CONFIG.ROOT_LAYOUT_CONTENT,
   )
 }
 
@@ -59,6 +59,6 @@ export async function getLayoutMetadata(
   return await client.fetch(
     layoutMetadataQuery,
     {},
-    NEXT_TAGS_CONFIG.LAYOUT_METADATA_CONTENT,
+    NEXT_CACHE_CONFIG.LAYOUT_METADATA_CONTENT,
   )
 }

--- a/src/lib/sanity/queries/sanity.pageContentQueries.ts
+++ b/src/lib/sanity/queries/sanity.pageContentQueries.ts
@@ -38,7 +38,7 @@ export async function performPageContentQuery<T extends keyof QueryReturnType>(
     ...,
     ${additionalQuery}
   }`
-  return await client.fetch(query, {}, SANITY_CLIENT_CACHE_SETTING)
+  return await client.fetch(query, {}, { next: { tags: [`'${param}'`] } })
 }
 
 const rootLayoutContentQuery = groq`*[_type == "rootLayoutContent"][0]`

--- a/src/lib/sanity/queries/sanity.pageContentQueries.ts
+++ b/src/lib/sanity/queries/sanity.pageContentQueries.ts
@@ -38,7 +38,7 @@ export async function performPageContentQuery<T extends keyof QueryReturnType>(
     ...,
     ${additionalQuery}
   }`
-  return await client.fetch(query, {}, { next: { tags: [`'${param}'`] } })
+  return await client.fetch(query, {}, { next: { tags: [param] } })
 }
 
 const rootLayoutContentQuery = groq`*[_type == "rootLayoutContent"][0]`

--- a/src/lib/sanity/queries/sanity.pageContentQueries.ts
+++ b/src/lib/sanity/queries/sanity.pageContentQueries.ts
@@ -12,7 +12,7 @@ import { PrivacyPolicyPageContent } from '~/schemas/pages/privacyPolicyPageConte
 import { RootLayoutContent } from '~/schemas/pages/rootLayoutContent'
 import { RootPageContent } from '~/schemas/pages/rootPageContent'
 
-import { getClient, SANITY_CLIENT_CACHE_SETTING } from '../sanity.client'
+import { getClient } from '../sanity.client'
 
 type QueryReturnType = {
   rootPageContent: RootPageContent

--- a/src/lib/sanity/sanity.client.ts
+++ b/src/lib/sanity/sanity.client.ts
@@ -1,5 +1,6 @@
 import {
   createClient,
+  FilteredResponseQueryOptions,
   SanityClient,
 } from '@sanity/client'
 
@@ -45,9 +46,23 @@ export function getPreviewClient(preview?: { token: string }): SanityClient {
   return client
 }
 
-export const NEXT_TAGS_CONFIG = {
+interface ICacheOptions {
+  [key: string]: FilteredResponseQueryOptions
+}
+
+const TAGS_CACHE: ICacheOptions = {
   ARTIST: { next: { tags: ['artist'] } },
   BOOKING: { next: { tags: ['booking'] } },
   ROOT_LAYOUT_CONTENT: { next: { tags: ['rootLayoutContent'] } },
   LAYOUT_METADATA_CONTENT: { next: { tags: ['layoutMetadataContent'] } },
 }
+
+const NO_CACHE: ICacheOptions = {
+  ARTIST: { cache: 'no-store' },
+  BOOKING: { cache: 'no-store' },
+  ROOT_LAYOUT_CONTENT: { cache: 'no-store' },
+  LAYOUT_METADATA_CONTENT: { cache: 'no-store' },
+}
+
+export const NEXT_CACHE_CONFIG =
+  process.env.NODE_ENV === 'production' ? TAGS_CACHE : NO_CACHE

--- a/src/lib/sanity/sanity.client.ts
+++ b/src/lib/sanity/sanity.client.ts
@@ -1,6 +1,5 @@
 import {
   createClient,
-  ResponseQueryOptions,
   SanityClient,
 } from '@sanity/client'
 
@@ -44,4 +43,11 @@ export function getPreviewClient(preview?: { token: string }): SanityClient {
     })
   }
   return client
+}
+
+export const NEXT_TAGS_CONFIG = {
+  ARTIST: { next: { tags: ['artist'] } },
+  BOOKING: { next: { tags: ['booking'] } },
+  ROOT_LAYOUT_CONTENT: { next: { tags: ['rootLayoutContent'] } },
+  LAYOUT_METADATA_CONTENT: { next: { tags: ['layoutMetadataContent'] } },
 }

--- a/src/lib/sanity/sanity.client.ts
+++ b/src/lib/sanity/sanity.client.ts
@@ -45,7 +45,3 @@ export function getPreviewClient(preview?: { token: string }): SanityClient {
   }
   return client
 }
-
-export const SANITY_CLIENT_CACHE_SETTING: ResponseQueryOptions = {
-  cache: 'no-cache',
-}


### PR DESCRIPTION
Closes #88 

This PR sets up tag-based validation for requests and uses Sanity webhooks to trigger revalidation.
It also cleans up some prefetching on routes that don't need it (ie. employee-portal and studio).