### PR TITLE
Employment Page + Bug Fixes

### DIFF
--- a/src/app/announcement/page.tsx
+++ b/src/app/announcement/page.tsx
@@ -7,7 +7,7 @@ import PageInProgress from '~/components/PageInProgress/PageInProgress'
 import { performPageContentQuery } from '~/lib/sanity/queries/sanity.pageContentQueries'
 
 export async function generateMetadata(): Promise<Metadata> {
-  const content = await performPageContentQuery('disclaimerPageContent')
+  const content = await performPageContentQuery('announcementPageContent')
   if (!content) return {}
 
   return {

--- a/src/app/employment/page.tsx
+++ b/src/app/employment/page.tsx
@@ -1,0 +1,39 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import GeneralPage from '~/components/GeneralPage/GeneralPage'
+import PageContainer from '~/components/PageContainer'
+import PageInProgress from '~/components/PageInProgress/PageInProgress'
+import { performPageContentQuery } from '~/lib/sanity/queries/sanity.pageContentQueries'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const content = await performPageContentQuery('employmentPageContent')
+  if (!content) return {}
+
+  return {
+    title: content.pageTitle,
+    description: content.metadataDescription,
+    openGraph: {
+      title: content.pageTitle,
+      description: content.metadataDescription,
+    },
+  }
+}
+
+const EmploymentPage = async () => {
+  const content = await performPageContentQuery('employmentPageContent')
+
+  if (!content) return notFound()
+
+  if (!content.isActive) {
+    return <PageInProgress />
+  }
+
+  return (
+    <PageContainer>
+      <GeneralPage {...content} />
+    </PageContainer>
+  )
+}
+
+export default EmploymentPage

--- a/src/components/PortableTextComponents/InternalLink.tsx
+++ b/src/components/PortableTextComponents/InternalLink.tsx
@@ -15,12 +15,13 @@ export function InternalLink(
 ) {
   const { value, children, inEditor = false } = props
   const page = value?.page || ''
-  const href = `/${encodeURIComponent(page)}`
+  const href = page.startsWith('mailto') ? page : `/${encodeURIComponent(page)}`
 
   return (
     <Anchor
       component={Link}
       href={inEditor ? '' : href}
+      target={page.startsWith('mailto') ? '_blank' : '_self'}
       {...getSharedLinkProps(inEditor)}
     >
       {children}

--- a/src/components/PortableTextComponents/PortableTextComponents.tsx
+++ b/src/components/PortableTextComponents/PortableTextComponents.tsx
@@ -36,9 +36,14 @@ export const PortableTextComponents: Partial<PortableTextReactComponents> = {
   },
   types: {
     image: ({ value }: { value: BlockContentImage }) => {
+      // When an image is uploaded from a UI rich text editor, the _key will match the asset reference
+      // - In this case, we should just pass the key and let the function format the reference
+      // When an image is uploaded in the Sanity Studio, the _key will not match the asset reference
+      // - In this case, we can trust the asset reference is properly formatted and pass it directly
+      const isUploadedFromUi = value._key === value.asset._ref
       return (
         <Image
-          src={getImageFromRef(value._key)?.url}
+          src={getImageFromRef(isUploadedFromUi ? value._key : value)?.url}
           alt={value.altText}
           radius="var(--mantine-radius-default)"
         />

--- a/src/lib/sanity/queries/sanity.pageContentQueries.ts
+++ b/src/lib/sanity/queries/sanity.pageContentQueries.ts
@@ -6,6 +6,7 @@ import { AnnouncementPageContent } from '~/schemas/pages/announcementPageContent
 import { ArtistsPageContent } from '~/schemas/pages/artistsPageContent'
 import { BookingInfoPageContent } from '~/schemas/pages/bookingInfoPageContent'
 import { DisclaimerPageContent } from '~/schemas/pages/disclaimerPageContent'
+import { EmploymentPageContent } from '~/schemas/pages/employmentPageContent'
 import { FaqPageContent } from '~/schemas/pages/faqPageContent'
 import { LayoutMetadataContent } from '~/schemas/pages/layoutMetadataContent'
 import { PrivacyPolicyPageContent } from '~/schemas/pages/privacyPolicyPageContent'
@@ -23,6 +24,7 @@ type QueryReturnType = {
   bookingInfoPageContent: BookingInfoPageContent
   disclaimerPageContent: DisclaimerPageContent
   announcementPageContent: AnnouncementPageContent
+  employmentPageContent: EmploymentPageContent
 }
 
 export async function performPageContentQuery<T extends keyof QueryReturnType>(

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -10,6 +10,7 @@ import artistsPageContent from './pages/artistsPageContent'
 import basePageContent from './pages/basePageContent'
 import bookingInfoPageContent from './pages/bookingInfoPageContent'
 import disclaimerPageContent from './pages/disclaimerPageContent'
+import employmentPageContent from './pages/employmentPageContent'
 import faqPageContent from './pages/faqPageContent'
 import layoutMetadataContent from './pages/layoutMetadataContent'
 import privacyPolicyPageContent from './pages/privacyPolicyPageContent'
@@ -29,6 +30,8 @@ export const schemaTypes = {
   aftercareInfoPageContent,
   artistsPageContent,
   bookingInfoPageContent,
+  announcementPageContent,
+  employmentPageContent,
   rootLayoutContent,
   layoutMetadataContent,
 }
@@ -47,6 +50,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     disclaimerPageContent,
     bookingInfoPageContent,
     announcementPageContent,
+    employmentPageContent,
     // Models
     artist,
     booking,

--- a/src/schemas/models/blockContent.ts
+++ b/src/schemas/models/blockContent.ts
@@ -34,6 +34,8 @@ export default defineType({
             name: 'internalLink',
             type: 'object',
             title: 'Internal link',
+            description:
+              'This can be used as a mailto link as well. Make sure the value starts with mailto for this.',
             fields: [
               {
                 name: 'page',

--- a/src/schemas/pages/employmentPageContent.ts
+++ b/src/schemas/pages/employmentPageContent.ts
@@ -1,0 +1,31 @@
+import { IconScript } from '@tabler/icons-react'
+import { defineField, defineType } from 'sanity'
+
+import { BaseSanitySchema } from '..'
+import { BlockContent } from '../models/blockContent'
+import { BasePageContent } from './basePageContent'
+
+export interface EmploymentPageContent
+  extends BaseSanitySchema<'employmentPageContent'>,
+    BasePageContent {
+  information?: BlockContent
+}
+
+export default defineType({
+  name: 'employmentPageContent',
+  type: 'document',
+  title: 'Employment Page Content',
+  icon: IconScript,
+  fields: [
+    defineField({
+      name: 'basePageContent',
+      type: 'basePageContent',
+      title: 'Base Page Content',
+    }),
+    defineField({
+      name: 'information',
+      title: 'Information',
+      type: 'blockContent',
+    }),
+  ],
+})

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -20,6 +20,7 @@ export enum NavigationPages {
   PrivacyPolicy = '/privacy-policy',
   Disclaimer = '/disclaimer',
   Announcement = '/announcement',
+  Employment = '/employment',
 }
 
 interface NavigationLink {


### PR DESCRIPTION
Employment Page added.

Bug fixes
- Image would not display in the portable text component when uploaded via Sanity. Fixed this by using the reference directly in this case.
- Announcement page metadata was using the wrong query. Updated with the correct query.