### PR TITLE
Admin Control For Employment Page and Normalize of Images

### DIFF
--- a/src/app/employee-portal/[id]/site-content/announcement/page.tsx
+++ b/src/app/employee-portal/[id]/site-content/announcement/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation'
 import { getServerSession } from 'next-auth'
 
-import AdminSiteContentControls from '~/components/AdminControls/AdminSiteContentControls'
+import AdminAnnouncementControls from '~/components/AdminControls/AdminAnnouncementControls'
 import PageContainer from '~/components/PageContainer'
 import PageTitle from '~/components/PageTitle/PageTitle'
 import {
@@ -44,7 +44,7 @@ const EmployeePortalSiteContentPage = async ({
   return (
     <PageContainer>
       <PageTitle title="Site Content" />
-      <AdminSiteContentControls
+      <AdminAnnouncementControls
         announcementPageContent={announcementPageContent}
         rootLayoutContent={rootLayoutContent}
       />

--- a/src/app/employee-portal/[id]/site-content/employment/page.tsx
+++ b/src/app/employee-portal/[id]/site-content/employment/page.tsx
@@ -1,0 +1,48 @@
+import { redirect } from 'next/navigation'
+import { getServerSession } from 'next-auth'
+
+import AdminEmploymentControls from '~/components/AdminControls/AdminEmploymentControls'
+import PageContainer from '~/components/PageContainer'
+import PageTitle from '~/components/PageTitle/PageTitle'
+import {
+  authOptions,
+  AuthorizedRoles,
+  REDIRECT_URL,
+  userIsAuthorizedForRoute,
+} from '~/lib/next-auth/auth.utils'
+import { getArtistById } from '~/lib/sanity/queries/sanity.artistsQuery'
+import { performPageContentQuery } from '~/lib/sanity/queries/sanity.pageContentQueries'
+import { getClient } from '~/lib/sanity/sanity.client'
+import { NavigationPages } from '~/utils/navigation'
+
+const authorizedAccessRoles: AuthorizedRoles[] = ['Owner']
+
+const EmployeePortalSiteContentPage = async ({
+  params,
+}: {
+  params: { id: string }
+}) => {
+  const client = getClient(undefined)
+  const artist = await getArtistById(client, decodeURI(params.id))
+  const session = await getServerSession(authOptions)
+  const employmentPageContent = await performPageContentQuery(
+    'employmentPageContent',
+  )
+
+  if (!artist || !userIsAuthorizedForRoute(session, authorizedAccessRoles)) {
+    redirect(
+      `${NavigationPages.Unauthorized}?${REDIRECT_URL}=${encodeURIComponent(
+        NavigationPages.EmployeePortal,
+      )}`,
+    )
+  }
+
+  return (
+    <PageContainer>
+      <PageTitle title="Site Content" />
+      <AdminEmploymentControls employmentPageContent={employmentPageContent} />
+    </PageContainer>
+  )
+}
+
+export default EmployeePortalSiteContentPage

--- a/src/components/AdminControls/AdminAnnouncementControls.tsx
+++ b/src/components/AdminControls/AdminAnnouncementControls.tsx
@@ -13,7 +13,7 @@ interface IAdminSiteContentControls {
   rootLayoutContent: RootLayoutContent
 }
 
-const AdminSiteContentControls = ({
+const AdminAnnouncementControls = ({
   announcementPageContent,
   rootLayoutContent,
 }: IAdminSiteContentControls) => {
@@ -38,4 +38,4 @@ const AdminSiteContentControls = ({
   )
 }
 
-export default AdminSiteContentControls
+export default AdminAnnouncementControls

--- a/src/components/AdminControls/AdminEmploymentControls.tsx
+++ b/src/components/AdminControls/AdminEmploymentControls.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { Box, Group } from '@mantine/core'
+
+import { EmploymentPageContent } from '~/schemas/pages/employmentPageContent'
+
+import AdminTextEditor from './AdminTextEditor/AdminTextEditor'
+
+interface IAdminEmploymentPageControls {
+  employmentPageContent: EmploymentPageContent
+}
+
+const AdminEmploymentControls = ({
+  employmentPageContent,
+}: IAdminEmploymentPageControls) => {
+  return (
+    <Group justify="space-around" align="start" gap="xl">
+      <Box w={{ base: '100%', sm: 900 }}>
+        <AdminTextEditor
+          title="Employment Page Content"
+          initialValue={employmentPageContent.information}
+          fieldName="information"
+          documentId={employmentPageContent._id}
+        />
+      </Box>
+    </Group>
+  )
+}
+
+export default AdminEmploymentControls

--- a/src/components/AdminControls/AdminTextEditor/AdminTextEditor.tsx
+++ b/src/components/AdminControls/AdminTextEditor/AdminTextEditor.tsx
@@ -23,6 +23,7 @@ import {
 } from '@portabletext/editor'
 import { EventListenerPlugin } from '@portabletext/editor/plugins'
 import { PortableText } from '@portabletext/react'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useState } from 'react'
 
@@ -63,8 +64,16 @@ const schemaDefinition = defineSchema({
   // See the rendering guide to learn more about each type.
 
   // Annotations are more complex marks that can hold data (for example, hyperlinks).
-  // Hide internal link for now
-  annotations: [{ name: 'link' } /*,{ name: 'internalLink' }*/],
+  annotations: [
+    {
+      name: 'link',
+      fields: [
+        { name: 'href', type: 'string' },
+        { name: 'blank', type: 'boolean' },
+      ],
+    },
+    { name: 'internalLink', fields: [{ name: 'page', type: 'string' }] },
+  ],
   // Lists apply to entire text blocks as well (for example, bullet, numbered).
   lists: [],
   // Inline objects hold arbitrary data that can be inserted into the text (for example, custom emoji).
@@ -175,7 +184,7 @@ interface IAdminTextEditor {
   documentId: string
 }
 
-const AdminTextEditor = ({
+const AdminTextEditorComponent = ({
   title,
   initialValue,
   fieldName,
@@ -280,5 +289,13 @@ const AdminTextEditor = ({
     </>
   )
 }
+
+const AdminTextEditor = dynamic(
+  () => Promise.resolve(AdminTextEditorComponent),
+  {
+    ssr: false,
+    loading: () => <LoadingOverlay visible={true} />,
+  },
+)
 
 export default AdminTextEditor

--- a/src/components/AdminControls/AdminTextEditor/AdminTextEditor.tsx
+++ b/src/components/AdminControls/AdminTextEditor/AdminTextEditor.tsx
@@ -36,7 +36,8 @@ import {
 } from '~/components/PortableTextComponents/InternalLink'
 import { PortableTextComponents } from '~/components/PortableTextComponents/PortableTextComponents'
 import { useErrorDialog } from '~/hooks/useErrorDialog'
-import { BlockContent, BlockContentImage } from '~/schemas/models/blockContent'
+import { normalizeImageReference } from '~/lib/sanity/sanity.image'
+import { BlockContent } from '~/schemas/models/blockContent'
 
 import classes from './AdminTextEditor.module.css'
 import EditorImage from './TextEditorToolbar/EditorImage/EditorImage'
@@ -151,13 +152,16 @@ const renderBlock = (
   fieldName: string,
 ) => {
   if (props.schemaType.name === 'image') {
-    const imageVal = props.value as unknown as BlockContentImage
-    return (
+    let imageVal = normalizeImageReference(props.value as unknown)
+
+    return imageVal ? (
       <EditorImage
         image={imageVal}
         documentId={documentId}
         fieldName={fieldName}
       />
+    ) : (
+      <></>
     )
   }
 

--- a/src/components/AdminControls/AdminTextEditor/TextEditorToolbar/EditorImage/EditorImage.tsx
+++ b/src/components/AdminControls/AdminTextEditor/TextEditorToolbar/EditorImage/EditorImage.tsx
@@ -94,7 +94,7 @@ const EditorImage = ({ image, documentId, fieldName }: IEditorImage) => {
 
       <Card.Section>
         <Image
-          src={getImageFromRef(image._key)?.url}
+          src={getImageFromRef(image)?.url}
           alt={image.altText}
           radius="var(--mantine-radius-default)"
         />

--- a/src/components/PortableTextComponents/PortableTextComponents.tsx
+++ b/src/components/PortableTextComponents/PortableTextComponents.tsx
@@ -1,7 +1,10 @@
 import { AnchorProps, Image } from '@mantine/core'
 import { PortableTextReactComponents } from '@portabletext/react'
 
-import { getImageFromRef } from '~/lib/sanity/sanity.image'
+import {
+  getImageFromRef,
+  normalizeImageReference,
+} from '~/lib/sanity/sanity.image'
 import { BlockContentImage } from '~/schemas/models/blockContent'
 
 import { ExternalLink } from './ExternalLink'
@@ -36,14 +39,10 @@ export const PortableTextComponents: Partial<PortableTextReactComponents> = {
   },
   types: {
     image: ({ value }: { value: BlockContentImage }) => {
-      // When an image is uploaded from a UI rich text editor, the _key will match the asset reference
-      // - In this case, we should just pass the key and let the function format the reference
-      // When an image is uploaded in the Sanity Studio, the _key will not match the asset reference
-      // - In this case, we can trust the asset reference is properly formatted and pass it directly
-      const isUploadedFromUi = value._key === value.asset._ref
+      const normalizedImage = normalizeImageReference(value)
       return (
         <Image
-          src={getImageFromRef(isUploadedFromUi ? value._key : value)?.url}
+          src={getImageFromRef(normalizedImage)?.url}
           alt={value.altText}
           radius="var(--mantine-radius-default)"
         />

--- a/src/lib/sanity/sanity.image.ts
+++ b/src/lib/sanity/sanity.image.ts
@@ -54,7 +54,7 @@ export const normalizeImageReference = (
       '_ref' in image.asset
     ) {
       // Already a valid image reference
-      // and image._key could be difference from image.asset._ref
+      // and image._key could be different from image.asset._ref
       return image as ImageReference
     }
 

--- a/src/lib/sanity/sanity.image.ts
+++ b/src/lib/sanity/sanity.image.ts
@@ -30,6 +30,47 @@ export const urlForImage = (source: Image) => {
   return imageBuilder?.image(source).auto('format')
 }
 
+/*
+ * Normalize an image reference to a consistent format.
+ */
+export const normalizeImageReference = (
+  image: ImageReference | { _key: string; _type: 'image' } | string | unknown,
+): ImageReference | null => {
+  if (typeof image === 'string') {
+    // Assume string is the _key
+    return {
+      _key: image,
+      _type: 'image',
+      asset: { _ref: image, _type: 'reference' },
+    }
+  }
+
+  if (typeof image === 'object' && image !== null) {
+    if (
+      'asset' in image &&
+      image.asset &&
+      typeof image.asset === 'object' &&
+      image.asset !== null &&
+      '_ref' in image.asset
+    ) {
+      // Already a valid image reference
+      // and image._key could be difference from image.asset._ref
+      return image as ImageReference
+    }
+
+    if ('_key' in image && image._key && typeof image._key === 'string') {
+      // Create a new reference from _key
+      return {
+        _key: image._key,
+        _type: 'image',
+        asset: { _ref: image._key, _type: 'reference' },
+      }
+    }
+  }
+
+  return null
+}
+
 export const getImageFromRef = (
   imageRef?: ImageReference | SanityImageSource | string | null,
 ): SanityImageAsset | undefined => {

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -15,6 +15,8 @@ export enum NavigationPages {
   EmployeePortalPortfolioSettings = '/portfolio-settings',
   EmployeePortalBookings = '/bookings',
   EmployeePortalSiteContent = '/site-content',
+  EmployeePortalSiteContentAnnouncement = '/site-content/announcement',
+  EmployeePortalSiteContentEmployment = '/site-content/employment',
   Studio = '/studio',
   Unauthorized = '/unauthorized',
   PrivacyPolicy = '/privacy-policy',


### PR DESCRIPTION
Adds admin control for employment page content.

Normalizes image references when dealing with rich text editors and portable text components. That way we have a single place to deal with the edge cases that come along with this.