### PR TITLE
Add support for lists in portable text editor

### DIFF
--- a/src/components/AdminControls/AdminSocialLinks/AdminSocialLinks.tsx
+++ b/src/components/AdminControls/AdminSocialLinks/AdminSocialLinks.tsx
@@ -134,9 +134,7 @@ const SortableItem = ({
       <Group wrap="nowrap" m="1rem 0" grow>
         <ActionIcon
           aria-label="Drag"
-          style={{
-            cursor: 'grab',
-          }}
+          style={{ touchAction: 'none', cursor: 'grab' }}
           {...attributes}
           {...listeners}
         >

--- a/src/components/AdminControls/AdminTextEditor/AdminTextEditor.tsx
+++ b/src/components/AdminControls/AdminTextEditor/AdminTextEditor.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import './listStyles.css'
+
 import {
   Anchor,
   Box,
@@ -19,6 +21,7 @@ import {
   PortableTextEditable,
   RenderAnnotationFunction,
   RenderDecoratorFunction,
+  RenderListItemFunction,
   RenderStyleFunction,
 } from '@portabletext/editor'
 import { EventListenerPlugin } from '@portabletext/editor/plugins'
@@ -60,9 +63,6 @@ const schemaDefinition = defineSchema({
     // { name: 'h6' },
   ],
 
-  // The types below are left empty for this example.
-  // See the rendering guide to learn more about each type.
-
   // Annotations are more complex marks that can hold data (for example, hyperlinks).
   annotations: [
     {
@@ -75,7 +75,7 @@ const schemaDefinition = defineSchema({
     { name: 'internalLink', fields: [{ name: 'page', type: 'string' }] },
   ],
   // Lists apply to entire text blocks as well (for example, bullet, numbered).
-  lists: [],
+  lists: [{ name: 'bullet' }, { name: 'number' }],
   // Inline objects hold arbitrary data that can be inserted into the text (for example, custom emoji).
   inlineObjects: [],
   // Block objects hold arbitrary data that live side-by-side with text blocks (for example, images, code blocks, and tables).
@@ -169,6 +169,26 @@ const renderAnnotation: RenderAnnotationFunction = (props) => {
         </Anchor>
       )
   }
+}
+
+/**
+ * Uses custom css located in listStyles.css to render the list items correctly.
+ * Hopefully we will get some better support for this in the future
+ * https://github.com/portabletext/editor/issues/192
+ * @param props - The props for the list item.
+ * @returns The rendered list item.
+ */
+const renderListItem: RenderListItemFunction = (props) => {
+  return <>{props.children}</>
+
+  // For some reason using Mantine components here causes some bad lag
+  // I am guessing because we are creating a whole new list each time
+  // Maybe when the portable text component has a better way to render lists we can use this.
+  // return (
+  //   <List withPadding type={props.value === 'number' ? 'ordered' : 'unordered'}>
+  //     <List.Item>{props.children}</List.Item>
+  //   </List>
+  // )
 }
 
 const renderBlock = (
@@ -272,6 +292,7 @@ const AdminTextEditorComponent = ({
                 renderStyle={renderStyle}
                 renderDecorator={renderDecorator}
                 renderAnnotation={renderAnnotation}
+                renderListItem={renderListItem}
                 renderBlock={(props) =>
                   renderBlock(props, documentId, fieldName)
                 }

--- a/src/components/AdminControls/AdminTextEditor/TextEditorToolbar/ListButton/ListButton.tsx
+++ b/src/components/AdminControls/AdminTextEditor/TextEditorToolbar/ListButton/ListButton.tsx
@@ -1,0 +1,42 @@
+import { useEditor, useEditorSelector } from '@portabletext/editor'
+import * as selectors from '@portabletext/editor/selectors'
+import { IconList, IconListNumbers } from '@tabler/icons-react'
+
+import BaseToolbarButton from '../BaseToolbarButton/BaseToolbarButton'
+
+const listIconMap = {
+  bullet: <IconList size={16} />,
+  number: <IconListNumbers size={16} />,
+} as const
+
+interface IListButton {
+  list: { name: keyof typeof listIconMap }
+}
+
+const ListButton = ({ list }: IListButton) => {
+  const listIcon: JSX.Element = listIconMap[list.name]
+  const editor = useEditor()
+
+  const active = useEditorSelector(
+    editor,
+    selectors.isActiveListItem(list.name),
+  )
+
+  const onListItemToggle = () => {
+    editor.send({
+      type: 'list item.toggle',
+      listItem: list.name,
+    })
+    editor.send({
+      type: 'focus',
+    })
+  }
+
+  return (
+    <BaseToolbarButton onClick={onListItemToggle} isActive={active}>
+      {listIcon}
+    </BaseToolbarButton>
+  )
+}
+
+export default ListButton

--- a/src/components/AdminControls/AdminTextEditor/TextEditorToolbar/TextEditorToolbar.tsx
+++ b/src/components/AdminControls/AdminTextEditor/TextEditorToolbar/TextEditorToolbar.tsx
@@ -6,6 +6,7 @@ import { CustomSchemaDefinition } from '../AdminTextEditor'
 import AnnotationButton from './AnnotationButton/AnnotationButton'
 import DecoratorButton from './DecoratorButton/DecoratorButton'
 import ImageButton from './ImageButton/ImageButton'
+import ListButton from './ListButton/ListButton'
 import StyleButton from './StyleButton/StyleButton'
 import classes from './TextEditorToolbar.module.css'
 
@@ -27,6 +28,10 @@ const TextEditorToolbar = ({ schemaDefinition }: ITextEditorToolbar) => {
     <AnnotationButton key={annotation.name} annotation={annotation} />
   ))
 
+  const listButtons = schemaDefinition.lists?.map((list) => (
+    <ListButton key={list.name} list={list} />
+  ))
+
   const imageButtons = schemaDefinition.blockObjects?.map((blockObject) => (
     <ImageButton key={blockObject.name} image={blockObject} />
   ))
@@ -35,6 +40,7 @@ const TextEditorToolbar = ({ schemaDefinition }: ITextEditorToolbar) => {
     <Group className={classes.toolbar}>
       <Button.Group>{styleButtons}</Button.Group>
       <Button.Group>{decoratorButtons}</Button.Group>
+      <Button.Group>{listButtons}</Button.Group>
       <Button.Group>{annotationButtons}</Button.Group>
       <Button.Group>{imageButtons}</Button.Group>
     </Group>

--- a/src/components/AdminControls/AdminTextEditor/listStyles.css
+++ b/src/components/AdminControls/AdminTextEditor/listStyles.css
@@ -1,0 +1,188 @@
+/**
+ * List styles when working with portable text editors.
+ * https://github.com/portabletext/editor/blob/main/examples/basic/src/editor.css
+ */
+
+[role='textbox'] {
+  --list-padding: 1em;
+  /**
+   * First, we initialize a counter for each block level.
+   */
+  counter-reset: level-1 level-2 level-3 level-4 level-5 level-6 level-7 level-8
+    level-9 level-10;
+}
+
+[data-list-item] {
+  display: flex;
+  gap: 0.5rem;
+}
+[data-list-item]::before {
+  text-align: right;
+  width: 1.5rem;
+}
+
+[data-list-item='number'] {
+  align-items: baseline;
+}
+[data-list-item='number']::before {
+  font-variant-numeric: tabular-nums;
+}
+
+[data-list-item='bullet'] {
+  align-items: center;
+}
+
+/**
+ * Then, the counter for each level is manually set to 1 whenever a list item
+ * with index 1 is encountered.
+ */
+[data-level='1'][data-list-index='1'] {
+  counter-set: level-1 1;
+}
+[data-level='2'][data-list-index='1'] {
+  counter-set: level-2 1;
+}
+[data-level='3'][data-list-index='1'] {
+  counter-set: level-3 1;
+}
+[data-level='4'][data-list-index='1'] {
+  counter-set: level-4 1;
+}
+[data-level='5'][data-list-index='1'] {
+  counter-set: level-5 1;
+}
+[data-level='6'][data-list-index='1'] {
+  counter-set: level-6 1;
+}
+[data-level='7'][data-list-index='1'] {
+  counter-set: level-7 1;
+}
+[data-level='8'][data-list-index='1'] {
+  counter-set: level-8 1;
+}
+[data-level='9'][data-list-index='1'] {
+  counter-set: level-9 1;
+}
+[data-level='10'][data-list-index='1'] {
+  counter-set: level-10 1;
+}
+
+/**
+ * Thereafter, the count for each list level is incremented for each index
+ * greater than 1.
+ */
+[data-level='1']:not([data-list-index='1']) {
+  counter-increment: level-1;
+}
+[data-level='2']:not([data-list-index='1']) {
+  counter-increment: level-2;
+}
+[data-level='3']:not([data-list-index='1']) {
+  counter-increment: level-3;
+}
+[data-level='4']:not([data-list-index='1']) {
+  counter-increment: level-4;
+}
+[data-level='5']:not([data-list-index='1']) {
+  counter-increment: level-5;
+}
+[data-level='6']:not([data-list-index='1']) {
+  counter-increment: level-6;
+}
+[data-level='7']:not([data-list-index='1']) {
+  counter-increment: level-7;
+}
+[data-level='8']:not([data-list-index='1']) {
+  counter-increment: level-8;
+}
+[data-level='9']:not([data-list-index='1']) {
+  counter-increment: level-9;
+}
+[data-level='10']:not([data-list-index='1']) {
+  counter-increment: level-10;
+}
+
+/**
+ * Finally, the calculated count is displayed in the list item.
+ */
+[data-list-item='number'][data-level='1']::before {
+  content: counter(level-1, decimal) '.';
+}
+[data-list-item='number'][data-level='2']::before {
+  content: counter(level-2, lower-alpha) '.';
+}
+[data-list-item='number'][data-level='3']::before {
+  content: counter(level-3, lower-roman) '.';
+}
+[data-list-item='number'][data-level='4']::before {
+  content: counter(level-4, decimal) '.';
+}
+[data-list-item='number'][data-level='5']::before {
+  content: counter(level-5, lower-alpha) '.';
+}
+[data-list-item='number'][data-level='6']::before {
+  content: counter(level-6, lower-roman) '.';
+}
+[data-list-item='number'][data-level='7']::before {
+  content: counter(level-7, decimal) '.';
+}
+[data-list-item='number'][data-level='8']::before {
+  content: counter(level-8, lower-alpha) '.';
+}
+[data-list-item='number'][data-level='9']::before {
+  content: counter(level-9, lower-roman) '.';
+}
+[data-list-item='number'][data-level='10']::before {
+  content: counter(level-10, decimal) '.';
+}
+
+/**
+ * Visual display of bulleted list items
+ */
+[data-list-item='bullet'][data-level='1']::before,
+[data-list-item='bullet'][data-level='4']::before,
+[data-list-item='bullet'][data-level='7']::before,
+[data-list-item='bullet'][data-level='10']::before {
+  content: '•';
+}
+[data-list-item='bullet'][data-level='2']::before,
+[data-list-item='bullet'][data-level='5']::before,
+[data-list-item='bullet'][data-level='8']::before {
+  content: '○';
+}
+[data-list-item='bullet'][data-level='3']::before,
+[data-list-item='bullet'][data-level='6']::before,
+[data-list-item='bullet'][data-level='9']::before {
+  content: '■';
+}
+
+/**
+ * Padding for each level of list item
+ */
+[data-level='2'] {
+  padding-left: calc(var(--list-padding));
+}
+[data-level='3'] {
+  padding-left: calc(var(--list-padding) * 2);
+}
+[data-level='4'] {
+  padding-left: calc(var(--list-padding) * 3);
+}
+[data-level='5'] {
+  padding-left: calc(var(--list-padding) * 4);
+}
+[data-level='6'] {
+  padding-left: calc(var(--list-padding) * 5);
+}
+[data-level='7'] {
+  padding-left: calc(var(--list-padding) * 6);
+}
+[data-level='8'] {
+  padding-left: calc(var(--list-padding) * 7);
+}
+[data-level='9'] {
+  padding-left: calc(var(--list-padding) * 8);
+}
+[data-level='10'] {
+  padding-left: calc(var(--list-padding) * 9);
+}

--- a/src/schemas/models/blockContent.ts
+++ b/src/schemas/models/blockContent.ts
@@ -64,6 +64,10 @@ export default defineType({
           },
         ],
       },
+      lists: [
+        { title: 'Bullet', value: 'bullet' },
+        { title: 'Numbered', value: 'number' },
+      ],
     }),
     defineArrayMember({
       type: 'image',


### PR DESCRIPTION
Adds supports for both bulleted and numbered list in the portable text editor. The portable text editor does have significant limitations with these, so it is just single level and base HTML elements.

Also fixes draggable items on mobile by setting the touch action CSS property.