### PR TITLE
Add preferred communication method to booking forms

### DIFF
--- a/src/app/api/sanity/booking/route.ts
+++ b/src/app/api/sanity/booking/route.ts
@@ -13,13 +13,15 @@ const token = process.env.SANITY_API_WRITE_TOKEN
 export async function PUT(request: NextRequest) {
   const client = getClient(token)
   const body = await request.json()
+  const documentType = body.isGeneric ? 'genericBooking' : 'booking'
   delete body.bodyPlacementImages // remove extra field
+  delete body.isGeneric // remove extra field
 
   try {
     console.log(`Start booking request create for ${body.name}: ${body.email}`)
     // Submit the form data to Sanity CMS
     const response = await client.create({
-      _type: body.isGeneric ? 'genericBooking' : 'booking',
+      _type: documentType,
       ...body,
     })
 

--- a/src/components/BooksStatus/ArtistBookStatus/ShowBooksOpen/GenericBookingForm/GenericBookingForm.tsx
+++ b/src/components/BooksStatus/ArtistBookStatus/ShowBooksOpen/GenericBookingForm/GenericBookingForm.tsx
@@ -6,6 +6,8 @@ import {
   Container,
   Group,
   LoadingOverlay,
+  Radio,
+  RadioGroupProps,
   Text,
   Textarea,
   TextareaProps,
@@ -27,6 +29,7 @@ import {
   GenericBookingField,
   getGenericBookingFormInitialValues,
   MAX_FILES,
+  preferredCommunicationMethodOptions,
   sendArtistBookingEmail,
   TGenericBookingSchema,
 } from '~/utils/forms/bookingFormUtils'
@@ -49,7 +52,7 @@ const inputSharedProps = (
   label: string,
   placeholder: string,
   isSubmitting: boolean,
-): Partial<TextInputProps & TextareaProps> => ({
+): Partial<TextInputProps & TextareaProps & RadioGroupProps> => ({
   className: 'w-full',
   withAsterisk: true,
   size: 'md' as const,
@@ -242,6 +245,29 @@ const GenericBookingForm = ({ onSuccess, onFailure }: IGenericBookingForm) => {
             {...form.getInputProps(GenericBookingField.Email.id)}
             type="email"
           />
+
+          <Radio.Group
+            {...inputSharedProps(
+              GenericBookingField.PreferredCommunicationMethod.id,
+              GenericBookingField.PreferredCommunicationMethod.label,
+              '',
+              isSubmitting,
+            )}
+            {...form.getInputProps(
+              GenericBookingField.PreferredCommunicationMethod.id,
+            )}
+          >
+            <Group mt="xs">
+              {preferredCommunicationMethodOptions.map(({ value, label }) => (
+                <Radio
+                  key={value}
+                  value={value}
+                  label={label}
+                  disabled={isSubmitting}
+                />
+              ))}
+            </Group>
+          </Radio.Group>
 
           <Textarea
             {...inputSharedProps(

--- a/src/components/BooksStatus/ArtistBookStatus/ShowBooksOpen/TattooForm/TattooForm.tsx
+++ b/src/components/BooksStatus/ArtistBookStatus/ShowBooksOpen/TattooForm/TattooForm.tsx
@@ -36,6 +36,7 @@ import {
   getBookingFormInitialValues,
   ImagesBookingField,
   MAX_FILES,
+  preferredCommunicationMethodOptions,
   priorTattooOptions,
   sendArtistBookingEmail,
   styleOptions,
@@ -325,6 +326,30 @@ const TattooForm = ({ onSuccess, onFailure }: ITattooForm) => {
             {...form.getInputProps(BookingField.Email.id)}
             type="email"
           />
+
+          {/* Preferred Communication Method */}
+          <Radio.Group
+            {...inputSharedProps(
+              BookingField.PreferredCommunicationMethod.id,
+              BookingField.PreferredCommunicationMethod.label,
+              '',
+              isSubmitting,
+            )}
+            {...form.getInputProps(
+              BookingField.PreferredCommunicationMethod.id,
+            )}
+          >
+            <Group mt="xs">
+              {preferredCommunicationMethodOptions.map(({ value, label }) => (
+                <Radio
+                  key={value}
+                  value={value}
+                  label={label}
+                  disabled={isSubmitting}
+                />
+              ))}
+            </Group>
+          </Radio.Group>
 
           {/* Instagram Name */}
           <TextInput

--- a/src/schemas/models/booking.ts
+++ b/src/schemas/models/booking.ts
@@ -31,6 +31,7 @@ export interface Booking extends BaseSanitySchema<'booking'> {
   preferredDays: string[]
   budget: string
   referenceImages: ImageReference[]
+  preferredCommunicationMethod?: 'email' | 'phone'
   artist: any
 }
 
@@ -150,6 +151,17 @@ export default defineType({
           name: 'image',
         }),
       ],
+    }),
+    defineField({
+      name: 'preferredCommunicationMethod',
+      type: 'string',
+      title: 'Preferred Communication Method',
+      options: {
+        list: [
+          { title: 'Email', value: 'email' },
+          { title: 'Phone', value: 'phone' },
+        ],
+      },
     }),
     defineField({
       name: 'artist',

--- a/src/schemas/models/genericBooking.ts
+++ b/src/schemas/models/genericBooking.ts
@@ -11,6 +11,7 @@ export interface GenericBooking extends BaseSanitySchema<'genericBooking'> {
   email: string
   description: string
   referenceImages: ImageReference[]
+  preferredCommunicationMethod?: 'email' | 'phone'
   artist: any
 }
 
@@ -51,6 +52,17 @@ export default defineType({
           name: 'image',
         }),
       ],
+    }),
+    defineField({
+      name: 'preferredCommunicationMethod',
+      type: 'string',
+      title: 'Preferred Communication Method',
+      options: {
+        list: [
+          { title: 'Email', value: 'email' },
+          { title: 'Phone', value: 'phone' },
+        ],
+      },
     }),
     defineField({
       name: 'artist',

--- a/src/utils/forms/bookingFormUtils.ts
+++ b/src/utils/forms/bookingFormUtils.ts
@@ -92,6 +92,24 @@ export const bookingDayChoices: ComboboxItem[] = [
   },
 ]
 
+const zPreferredCommunicationMethod = z.enum(['email', 'phone'])
+type TPreferredCommunicationMethod = z.infer<
+  typeof zPreferredCommunicationMethod
+>
+export const preferredCommunicationMethodOptions: {
+  value: TPreferredCommunicationMethod
+  label: string
+}[] = [
+  {
+    value: 'email',
+    label: 'Email',
+  },
+  {
+    value: 'phone',
+    label: 'Phone',
+  },
+]
+
 export const getArtistAvailableDays = (
   artistAvailability: string[] | null | undefined,
 ): ComboboxItem[] => {
@@ -238,6 +256,7 @@ export const generateBookingFormSchema = (artist: Artist): z.ZodObject<any> => {
       .min(1, locationError),
     style: zTattooStyle,
     priorTattoo: zPriorTattoo,
+    preferredCommunicationMethod: zPreferredCommunicationMethod,
     preferredDays: z
       .string({ required_error: preferredDayError })
       .array()
@@ -331,6 +350,15 @@ export const BookingField = {
     placeholder: 'Enter your email',
     initialValue: '',
     getValue: (email: string) => email,
+  },
+  PreferredCommunicationMethod: {
+    id: 'preferredCommunicationMethod',
+    label: 'Preferred Communication Method',
+    initialValue: preferredCommunicationMethodOptions[0].value,
+    getValue: (method: string) =>
+      preferredCommunicationMethodOptions.find(
+        (option) => option.value === method,
+      )?.label || 'Email',
   },
   InstagramName: {
     id: 'instagramName',
@@ -431,6 +459,15 @@ export const GenericBookingField = {
     initialValue: '',
     getValue: (email: string) => email,
   },
+  PreferredCommunicationMethod: {
+    id: 'preferredCommunicationMethod',
+    label: 'Preferred Communication Method',
+    initialValue: preferredCommunicationMethodOptions[0].value,
+    getValue: (method: string) =>
+      preferredCommunicationMethodOptions.find(
+        (option) => option.value === method,
+      )?.label || 'Email',
+  },
   Description: {
     id: 'description',
     label: 'Description',
@@ -488,12 +525,17 @@ export const sendArtistBookingEmail = async ({
       return base64
     }),
   )
+  const artistEmail =
+    Array.isArray(artist.bookingEmails) && artist.bookingEmails.length > 0
+      ? artist.bookingEmails
+      : artist.email
+
   return fetch('/api/mail', {
     method: 'PUT',
     body: JSON.stringify({
       ...emailTextData,
       isGeneric: isGenericForm,
-      artistEmail: artist.bookingEmails ?? artist.email,
+      artistEmail: artistEmail,
       base64Images,
     }),
   })


### PR DESCRIPTION
Also fixes possible bug where artist emails array was being passed empty. I _think_ this may have been a change in how the Sanity API returns empty array fields. Seems like it now is an empty array, which does not equate to a falsey value, where before it was null or undefined.